### PR TITLE
Fixed the certificate path in the HPPClient.

### DIFF
--- a/nintendo/nex/hpp.py
+++ b/nintendo/nex/hpp.py
@@ -21,7 +21,7 @@ class HppClient:
 		
 		self.call_id = 1
 		
-		ca = resources.certificate("files/cert/Nintendo_Class_2_CA_G3.der")
+		ca = resources.certificate("Nintendo_Class_2_CA_G3.der")
 		self.context = tls.TLSContext()
 		self.context.set_authority(ca)
 


### PR DESCRIPTION
Hello, i found an error in the HppClient certificate loading. The code was looking for `files/cert/Nintendo_Class_2_CA_G3.der`, but since resources.certificate already accesses the `files/cert` directory, I corrected it to use just the certificate filename `Nintendo_Class_2_CA_G3.der`.